### PR TITLE
Remove requirement of lat long being integer

### DIFF
--- a/app/Http/Requests/GetWeatherRequest.php
+++ b/app/Http/Requests/GetWeatherRequest.php
@@ -26,8 +26,8 @@ class GetWeatherRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'lat' => ['required', 'integer', 'numeric'],
-            'lng' => ['required', 'integer', 'numeric']
+            'lat' => ['required', 'numeric'],
+            'lng' => ['required', 'numeric']
         ];
     }
 }


### PR DESCRIPTION
# Description
Lat and long can be decimal values so the integer requirement is not accurate.